### PR TITLE
Native WebSocket client using Network.framework

### DIFF
--- a/ios-sockets/SwiftWebSockets/SwiftWebSockets.xcodeproj/project.pbxproj
+++ b/ios-sockets/SwiftWebSockets/SwiftWebSockets.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		533FFCAB2518C15B00EEC543 /* NWWebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533FFCAA2518C15B00EEC543 /* NWWebSocket.swift */; };
 		6830574E234777B000EAA4B6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6830574D234777B000EAA4B6 /* AppDelegate.swift */; };
 		68305750234777B000EAA4B6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6830574F234777B000EAA4B6 /* SceneDelegate.swift */; };
 		68305752234777B000EAA4B6 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68305751234777B000EAA4B6 /* ContentView.swift */; };
@@ -20,6 +21,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		533FFCAA2518C15B00EEC543 /* NWWebSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NWWebSocket.swift; sourceTree = "<group>"; };
 		6830574A234777B000EAA4B6 /* SwiftWebSockets.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftWebSockets.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6830574D234777B000EAA4B6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6830574F234777B000EAA4B6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -96,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				6877D29A2347A28100058909 /* NativeWebSocket.swift */,
+				533FFCAA2518C15B00EEC543 /* NWWebSocket.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -198,6 +201,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				533FFCAB2518C15B00EEC543 /* NWWebSocket.swift in Sources */,
 				6830574E234777B000EAA4B6 /* AppDelegate.swift in Sources */,
 				683057622347850E00EAA4B6 /* KeyboardResponder.swift in Sources */,
 				6877D29B2347A28100058909 /* NativeWebSocket.swift in Sources */,

--- a/ios-sockets/SwiftWebSockets/SwiftWebSockets/Models/Model.swift
+++ b/ios-sockets/SwiftWebSockets/SwiftWebSockets/Models/Model.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Network
 
 class Model: ObservableObject, WebSocketConnectionDelegate {
     @Published var messages = [Message]()
@@ -20,35 +21,39 @@ class Model: ObservableObject, WebSocketConnectionDelegate {
     
     func send(_ message: String){
         messages.append(Message(message: message, me: true))
-        socket?.send(text: message)
+        socket?.send(string: message)
     }
     
     // Delegates
-    func onConnected(connection: WebSocketConnection) {
+    func webSocketDidConnect(connection: WebSocketConnection) {
         print("connected")
     }
     
-    func onDisconnected(connection: WebSocketConnection, error: Error?) {
+    func webSocketDidDisconnect(connection: WebSocketConnection, closeCode: NWProtocolWebSocket.CloseCode, reason: Data?) {
         print("disconnected")
     }
     
-    func onError(connection: WebSocketConnection, error: Error) {
+    func webSocketDidReceiveError(connection: WebSocketConnection, error: Error) {
         print(error)
     }
     
-    func onMessage(connection: WebSocketConnection, text: String) {
-        if messages.last?.message != text {
+    func webSocketDidReceiveMessage(connection: WebSocketConnection, string: String) {
+        if messages.last?.message != string {
             DispatchQueue.main.async {
-                self.messages.append(Message(message: text, me: false))
+                self.messages.append(Message(message: string, me: false))
             }
         }
     }
     
-    func onMessage(connection: WebSocketConnection, data: Data) {
+    func webSocketDidReceiveMessage(connection: WebSocketConnection, data: Data) {
         if let message = String(data: data, encoding: .utf8), messages.last?.message != message {
             DispatchQueue.main.async {
                 self.messages.append(Message(message: message, me: false))
             }
         }
+    }
+
+    func webSocketDidReceivePong(connection: WebSocketConnection) {
+        print("received pong")
     }
 }

--- a/ios-sockets/SwiftWebSockets/SwiftWebSockets/Models/Model.swift
+++ b/ios-sockets/SwiftWebSockets/SwiftWebSockets/Models/Model.swift
@@ -12,10 +12,10 @@ import Network
 class Model: ObservableObject, WebSocketConnectionDelegate {
     @Published var messages = [Message]()
     
-    var socket: NativeWebSocket?
+    var socket: NWWebSocket?
     
     init() {
-        socket = NativeWebSocket(url: URL(string: "ws://localhost:3000")!, autoConnect: true)
+        socket = NWWebSocket(url: URL(string: "ws://localhost:3000")!, connectAutomatically: true)
         socket?.delegate = self
     }
     

--- a/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NWWebSocket.swift
+++ b/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NWWebSocket.swift
@@ -1,0 +1,226 @@
+//
+//  NWWebSocket.swift
+//  SwiftWebSockets
+//
+//  Created by Dan Browne on 21/09/2020.
+//  Copyright © 2020 Neas Lease. All rights reserved.
+//
+
+import Foundation
+import Network
+
+open class NWWebSocket: WebSocketConnection {
+
+    // MARK: - Public properties
+
+    weak var delegate: WebSocketConnectionDelegate?
+
+    // MARK: - Private properties
+
+    private let connection: NWConnection
+    private let endpoint: NWEndpoint
+    private let parameters: NWParameters
+    private var pingTimer: Timer?
+
+    // MARK: - Initialization
+
+    init(request: URLRequest, connectAutomatically: Bool = false) {
+
+        endpoint = .url(request.url!)
+
+        if request.url?.port == 80 {
+            parameters = NWParameters.tcp
+        } else {
+            parameters = NWParameters.tls
+        }
+
+        let wsOptions = NWProtocolWebSocket.Options()
+        wsOptions.autoReplyPing = true
+        parameters.defaultProtocolStack.applicationProtocols.insert(wsOptions, at: 0)
+
+        connection = NWConnection(to: endpoint, using: parameters)
+
+        if connectAutomatically {
+            connect()
+        }
+    }
+
+    init(url: URL, connectAutomatically: Bool = false) {
+
+        endpoint = .url(url)
+
+        if url.port == 80 {
+            parameters = NWParameters.tcp
+        } else {
+            parameters = NWParameters.tls
+        }
+
+        let wsOptions = NWProtocolWebSocket.Options()
+        wsOptions.autoReplyPing = true
+        parameters.defaultProtocolStack.applicationProtocols.insert(wsOptions, at: 0)
+
+        connection = NWConnection(to: endpoint, using: parameters)
+
+        if connectAutomatically {
+            connect()
+        }
+    }
+
+    // MARK: - WebSocketConnection conformance
+
+    func connect() {
+        connection.stateUpdateHandler = stateDidChange(to:)
+        listen()
+        connection.start(queue: .main)
+    }
+
+    func send(string: String) {
+        guard let data = string.data(using: .utf8) else {
+            return
+        }
+        let metadata = NWProtocolWebSocket.Metadata(opcode: .text)
+        let context = NWConnection.ContentContext(identifier: "textContext", metadata: [metadata])
+
+        send(data: data, context: context)
+    }
+
+    func send(data: Data) {
+        let metadata = NWProtocolWebSocket.Metadata(opcode: .binary)
+        let context = NWConnection.ContentContext(identifier: "binaryContext", metadata: [metadata])
+
+        send(data: data, context: context)
+    }
+
+    func listen() {
+        connection.receiveMessage { [weak self] (data, context, _, error) in
+            guard let self = self else {
+                return
+            }
+
+            if let data = data, !data.isEmpty, let context = context {
+                self.handleMessage(data: data, context: context)
+            }
+
+            if let error = error {
+                self.connectionDidFail(error: error)
+            } else {
+                self.listen()
+            }
+        }
+    }
+
+    func ping(interval: TimeInterval) {
+        pingTimer = .scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            guard let self = self else {
+                return
+            }
+
+            self.ping()
+        }
+    }
+
+    func ping() {
+        let metadata = NWProtocolWebSocket.Metadata(opcode: .ping)
+        metadata.setPongHandler(.main) { [weak self] error in
+            guard let self = self else {
+                return
+            }
+
+            self.delegate?.webSocketDidReceivePong(connection: self)
+
+            if let error = error {
+                self.connectionDidFail(error: error)
+            }
+        }
+        let context = NWConnection.ContentContext(identifier: "pingContext", metadata: [metadata])
+
+        send(data: Data(), context: context)
+    }
+
+    func disconnect(closeCode: NWProtocolWebSocket.CloseCode = .protocolCode(.normalClosure)) {
+        connectionDidEnd(closeCode: closeCode, reason: nil)
+        pingTimer?.invalidate()
+    }
+
+    // MARK: - Private methods
+
+    private func handleMessage(data: Data, context: NWConnection.ContentContext) {
+        guard let metadata = context.protocolMetadata.first as? NWProtocolWebSocket.Metadata else {
+            return
+        }
+
+        switch metadata.opcode {
+        case .binary:
+            self.delegate?.webSocketDidReceiveMessage(connection: self, data: data)
+        case .cont:
+            //
+            break
+        case .text:
+            guard let string = String(data: data, encoding: .utf8) else {
+                return
+            }
+            self.delegate?.webSocketDidReceiveMessage(connection: self, string: string)
+        case .close:
+            connectionDidEnd(closeCode: metadata.closeCode, reason: data)
+        case .ping:
+            // SEE `autoReplyPing = true` in `init()`.
+            break
+        case .pong:
+            // SEE `ping()` FOR PONG RECEIVE LOGIC.
+            break
+        @unknown default:
+            fatalError()
+        }
+    }
+
+    private func send(data: Data?, context: NWConnection.ContentContext) {
+        connection.send(content: data,
+                        contentContext: context,
+                        isComplete: true,
+                        completion: .contentProcessed({ [weak self] error in
+                            guard let self = self else {
+                                return
+                            }
+
+                            if let error = error {
+                                self.connectionDidFail(error: error)
+                            }
+                        }))
+    }
+
+    private func connectionDidFail(error: NWError) {
+        delegate?.webSocketDidReceiveError(connection: self, error: error)
+        stop(error: error)
+    }
+
+    private func stateDidChange(to state: NWConnection.State) {
+        switch state {
+        case .ready:
+            delegate?.webSocketDidConnect(connection: self)
+        case .waiting(let error), .failed(let error):
+            connectionDidFail(error: error)
+        case .setup:
+            //
+            break
+        case .preparing:
+            //
+            break
+        case .cancelled:
+            //
+            break
+        @unknown default:
+            fatalError()
+        }
+    }
+
+    private func connectionDidEnd(closeCode: NWProtocolWebSocket.CloseCode, reason: Data?) {
+        delegate?.webSocketDidDisconnect(connection: self, closeCode: closeCode, reason: reason)
+        stop(error: nil)
+    }
+
+    private func stop(error: Error?) {
+        connection.stateUpdateHandler = nil
+        connection.cancel()
+    }
+}
+

--- a/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NWWebSocket.swift
+++ b/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NWWebSocket.swift
@@ -124,7 +124,7 @@ open class NWWebSocket: WebSocketConnection {
 
     func ping() {
         let metadata = NWProtocolWebSocket.Metadata(opcode: .ping)
-        metadata.setPongHandler(.main) { [weak self] error in
+        metadata.setPongHandler(connectionQueue) { [weak self] error in
             guard let self = self else {
                 return
             }

--- a/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NWWebSocket.swift
+++ b/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NWWebSocket.swift
@@ -141,6 +141,11 @@ open class NWWebSocket: WebSocketConnection {
     }
 
     func disconnect(closeCode: NWProtocolWebSocket.CloseCode = .protocolCode(.normalClosure)) {
+        let metadata = NWProtocolWebSocket.Metadata(opcode: .close)
+        metadata.closeCode = closeCode
+        let context = NWConnection.ContentContext(identifier: "textContext", metadata: [metadata])
+
+        send(data: nil, context: context)
         connectionDidEnd(closeCode: closeCode, reason: nil)
         pingTimer?.invalidate()
     }

--- a/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NWWebSocket.swift
+++ b/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NWWebSocket.swift
@@ -29,7 +29,7 @@ open class NWWebSocket: WebSocketConnection {
 
         endpoint = .url(request.url!)
 
-        if request.url?.port == 80 {
+        if request.url?.scheme == "ws" {
             parameters = NWParameters.tcp
         } else {
             parameters = NWParameters.tls
@@ -51,7 +51,7 @@ open class NWWebSocket: WebSocketConnection {
 
         endpoint = .url(url)
 
-        if url.port == 80 {
+        if url.scheme == "ws" {
             parameters = NWParameters.tcp
         } else {
             parameters = NWParameters.tls

--- a/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NWWebSocket.swift
+++ b/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NWWebSocket.swift
@@ -20,11 +20,12 @@ open class NWWebSocket: WebSocketConnection {
     private let connection: NWConnection
     private let endpoint: NWEndpoint
     private let parameters: NWParameters
+    private let connectionQueue: DispatchQueue
     private var pingTimer: Timer?
 
     // MARK: - Initialization
 
-    init(request: URLRequest, connectAutomatically: Bool = false) {
+    init(request: URLRequest, connectAutomatically: Bool = false, connectionQueue: DispatchQueue = .global(qos: .default)) {
 
         endpoint = .url(request.url!)
 
@@ -39,13 +40,14 @@ open class NWWebSocket: WebSocketConnection {
         parameters.defaultProtocolStack.applicationProtocols.insert(wsOptions, at: 0)
 
         connection = NWConnection(to: endpoint, using: parameters)
+        self.connectionQueue = connectionQueue
 
         if connectAutomatically {
             connect()
         }
     }
 
-    init(url: URL, connectAutomatically: Bool = false) {
+    init(url: URL, connectAutomatically: Bool = false, connectionQueue: DispatchQueue = .global(qos: .default)) {
 
         endpoint = .url(url)
 
@@ -60,6 +62,7 @@ open class NWWebSocket: WebSocketConnection {
         parameters.defaultProtocolStack.applicationProtocols.insert(wsOptions, at: 0)
 
         connection = NWConnection(to: endpoint, using: parameters)
+        self.connectionQueue = connectionQueue
 
         if connectAutomatically {
             connect()
@@ -71,7 +74,7 @@ open class NWWebSocket: WebSocketConnection {
     func connect() {
         connection.stateUpdateHandler = stateDidChange(to:)
         listen()
-        connection.start(queue: .main)
+        connection.start(queue: connectionQueue)
     }
 
     func send(string: String) {

--- a/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NativeWebSocket.swift
+++ b/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NativeWebSocket.swift
@@ -69,14 +69,12 @@ class NativeWebSocket: NSObject, WebSocketConnection, URLSessionWebSocketDelegat
     }
     
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
-        delegate?.onConnected(connection: self)
-//        DispatchQueue.main.async { [weak self] in
-//            self?.ping()
-//        }
+        delegate?.webSocketDidConnect(connection: self)
     }
     
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
-        delegate?.onDisconnected(connection: self, error: nil)
+        let nwCloseCode = try! NWProtocolWebSocket.CloseCode(rawValue: UInt16(closeCode.rawValue))
+        delegate?.webSocketDidDisconnect(connection: self, closeCode: nwCloseCode, reason: reason)
     }
     
     func connect() {
@@ -85,12 +83,12 @@ class NativeWebSocket: NSObject, WebSocketConnection, URLSessionWebSocketDelegat
         listen()
     }
     
-    func send(text: String) {
-        let textMessage = URLSessionWebSocketTask.Message.string(text)
+    func send(string: String) {
+        let textMessage = URLSessionWebSocketTask.Message.string(string)
         webSocketTask.send(textMessage) { [weak self] error in
             guard let self = self else { return }
             if let error = error {
-                self.delegate?.onError(connection: self, error: error)
+                self.delegate?.webSocketDidReceiveError(connection: self, error: error)
             }
         }
     }
@@ -100,7 +98,7 @@ class NativeWebSocket: NSObject, WebSocketConnection, URLSessionWebSocketDelegat
         webSocketTask.send(dataMessage) { [weak self] error in
             guard let self = self else { return }
             if let error = error {
-                self.delegate?.onError(connection: self, error: error)
+                self.delegate?.webSocketDidReceiveError(connection: self, error: error)
             }
         }
     }
@@ -111,13 +109,13 @@ class NativeWebSocket: NSObject, WebSocketConnection, URLSessionWebSocketDelegat
             guard let self = self else { return }
             switch result {
             case .failure(let error):
-                self.delegate?.onError(connection: self, error: error)
+                self.delegate?.webSocketDidReceiveError(connection: self, error: error)
             case .success(let message):
                 switch message {
                 case .string(let text):
-                    self.delegate?.onMessage(connection: self, text: text)
+                    self.delegate?.webSocketDidReceiveMessage(connection: self, string: text)
                 case .data(let data):
-                    self.delegate?.onMessage(connection: self, data: data)
+                    self.delegate?.webSocketDidReceiveMessage(connection: self, data: data)
                 @unknown default:
                     fatalError()
                 }
@@ -126,19 +124,33 @@ class NativeWebSocket: NSObject, WebSocketConnection, URLSessionWebSocketDelegat
         }
     }
     
-    func ping(with frequency: TimeInterval = 25.0) {
-        pingTimer = Timer.scheduledTimer(withTimeInterval: frequency, repeats: true) { [weak self] _ in
+    func ping(interval: TimeInterval = 25.0) {
+        pingTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             guard let self = self else { return }
-            self.webSocketTask.sendPing { error in
-                if let error = error {
-                    self.delegate?.onError(connection: self, error: error)
-                }
+            self.ping()
+        }
+    }
+
+    func ping() {
+        self.webSocketTask.sendPing { error in
+            if let error = error {
+                self.delegate?.webSocketDidReceiveError(connection: self, error: error)
             }
         }
     }
     
-    func disconnect() {
-        webSocketTask.cancel(with: .normalClosure, reason: nil)
+    func disconnect(closeCode: NWProtocolWebSocket.CloseCode) {
+        var webSocketTaskCloseCode: URLSessionWebSocketTask.CloseCode!
+        switch closeCode {
+        case .protocolCode(let definedCode):
+            webSocketTaskCloseCode = URLSessionWebSocketTask.CloseCode(rawValue: Int(definedCode.rawValue))
+        case .applicationCode, .privateCode:
+            webSocketTaskCloseCode = .normalClosure
+        @unknown default:
+            fatalError()
+        }
+
+        webSocketTask.cancel(with: webSocketTaskCloseCode, reason: nil)
         pingTimer?.invalidate()
     }
 }

--- a/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NativeWebSocket.swift
+++ b/ios-sockets/SwiftWebSockets/SwiftWebSockets/Networking/NativeWebSocket.swift
@@ -7,30 +7,50 @@
 //
 
 import Foundation
+import Network
 
-// define what WebSocketConnections can do
+/// Defines a websocket connection.
 protocol WebSocketConnection {
+    /// Connect to the websocket.
     func connect()
-    func send(text: String)
+
+    /// Send a UTF-8 formatted `String` over the websocket.
+    /// - Parameter string: The `String` that will be sent.
+    func send(string: String)
+
+    /// Send some `Data` over the websocket.
+    /// - Parameter data: The `Data` that will be sent.
     func send(data: Data)
+
+    /// Start listening for messages over the websocket.
     func listen()
-    func ping(with: TimeInterval)
-    func disconnect()
+
+    /// Ping the websocket periodically.
+    /// - Parameter interval: The `TimeInterval` (in seconds) with which to ping the server.
+    func ping(interval: TimeInterval)
+
+    /// Ping the websocket once.
+    func ping()
+
+    /// Disconnect from the websocket.
+    /// - Parameter closeCode: The code to use when closing the websocket connection.
+    func disconnect(closeCode: NWProtocolWebSocket.CloseCode)
+
     var delegate: WebSocketConnectionDelegate? { get set }
 }
 
-protocol WebSocketConnectionDelegate: class {
-    func onConnected(connection: WebSocketConnection)
-    func onDisconnected(connection: WebSocketConnection, error: Error?)
-    func onError(connection: WebSocketConnection, error: Error)
-    func onMessage(connection: WebSocketConnection, text: String)
-    func onMessage(connection: WebSocketConnection, data: Data)
+/// Defines a delegate for a websocket connection.
+protocol WebSocketConnectionDelegate: AnyObject {
+    func webSocketDidConnect(connection: WebSocketConnection)
+    func webSocketDidDisconnect(connection: WebSocketConnection,
+                                closeCode: NWProtocolWebSocket.CloseCode,
+                                reason: Data?)
+    func webSocketDidReceiveError(connection: WebSocketConnection, error: Error)
+    func webSocketDidReceivePong(connection: WebSocketConnection)
+    func webSocketDidReceiveMessage(connection: WebSocketConnection, string: String)
+    func webSocketDidReceiveMessage(connection: WebSocketConnection, data: Data)
 }
 
-extension WebSocketConnectionDelegate {
-    func onMessage(connection: WebSocketConnection, text: String) {}
-    func onMessage(connection: WebSocketConnection, data: Data) {}
-}
 
 class NativeWebSocket: NSObject, WebSocketConnection, URLSessionWebSocketDelegate {
     weak var delegate: WebSocketConnectionDelegate?


### PR DESCRIPTION
This PR resolves #17:

- Adds `NWWebSocket` (WebSocket client using Network.framework).
- Refactors `WebSocketConnection` and `WebSocketConnection` delegates (for method naming best practices).
- Refactors `NativeWebSocket` based on delegate method signature changes.

**NOTES:**
- I didn't have a localhost WebSocket server available, so I tested with wss://echo.websocket.org (locally commenting out the `if messages.last?.message != string` on line 41 of `Model.swift` when doing so)